### PR TITLE
Implement fallback for invalid ClientConfig language

### DIFF
--- a/app/lib/Utils/ClientConfig.php
+++ b/app/lib/Utils/ClientConfig.php
@@ -11,10 +11,13 @@ class ClientConfig
 
     public function __construct(string $language = "zh_TW")
     {
-        if (ELanguageCode::isVaild($language)) {
-            $this->language = $language;
-            $this->languageClass = ELanguageCode::valueof($language);
+        if (!ELanguageCode::isVaild($language)) {
+            // Fallback to default language when the given code is invalid
+            $language = ELanguageCode::zh_TW->name;
         }
+
+        $this->language = $language;
+        $this->languageClass = ELanguageCode::valueof($language);
     }
 
     /**

--- a/tests/Unit/ClientConfigTest.php
+++ b/tests/Unit/ClientConfigTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Lib\Utils\ClientConfig;
+use App\Lib\I18N\ELanguageCode;
+use Tests\TestCase;
+
+class ClientConfigTest extends TestCase
+{
+    public function test_invalid_language_defaults_to_zh_tw(): void
+    {
+        $config = new ClientConfig('invalid');
+        $this->assertEquals(ELanguageCode::zh_TW->name, $config->getLanguage());
+        $this->assertEquals(ELanguageCode::zh_TW, $config->getLanguageClass());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `ClientConfig` always assigns language
- test fallback behavior when passing an invalid language

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: Vite manifest not found, encryption key missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684000d2e50c8323a9871eb9a06c761f