### PR TITLE
Fix FK migrations and update tests

### DIFF
--- a/app/Models/DashVideos.php
+++ b/app/Models/DashVideos.php
@@ -50,7 +50,7 @@ class DashVideos extends Model
 
     public function shareTableVirtualFile(): BelongsTo
     {
-        return $this->belongsTo(ShareTableVirtualFile::class, 'id', 'dash_videos_id');
+        return $this->belongsTo(ShareTableVirtualFile::class, 'share_table_virtual_file_id', 'id');
     }
 
     public function member(): HasOne

--- a/database/factories/VirtualFileFactory.php
+++ b/database/factories/VirtualFileFactory.php
@@ -20,7 +20,7 @@ class VirtualFileFactory extends Factory
             'extension' => $this->faker->word(),
             'minetypes' => $this->faker->word(),
             'disk' => $this->faker->word(),
-            'expires_at' => $this->faker->randomNumber(),
+            'expired_at' => $this->faker->randomNumber(),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ];

--- a/database/migrations/2025_01_29_191123_create_dash_videos_table.php
+++ b/database/migrations/2025_01_29_191123_create_dash_videos_table.php
@@ -43,7 +43,10 @@ return new class extends Migration {
             });
 
         Schema::table('share_table_virtual_file', function (Blueprint $table) {
-            $table->foreignId('dash_videos_id')->comment('關聯 dash_videos 表')->change()->constrained('dash_videos')->onDelete('cascade');
+            $table->foreign('dash_videos_id')
+                ->references('id')
+                ->on('dash_videos')
+                ->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2025_02_23_051354_share_table_virtual_file.php
+++ b/database/migrations/2025_02_23_051354_share_table_virtual_file.php
@@ -8,7 +8,10 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('share_table_virtual_file', function (Blueprint $table) {
-            $table->foreignId('dash_videos_id')->default(null)->nullable(true)->change();
+            $table->foreign('dash_videos_id')
+                ->references('id')
+                ->on('dash_videos')
+                ->onDelete('cascade');
         });
     }
 

--- a/tests/Unit/MigrationForeignKeyTest.php
+++ b/tests/Unit/MigrationForeignKeyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Member;
+use App\Models\ShareTable;
+use App\Models\VirtualFile;
+use App\Models\ShareTableVirtualFile;
+use App\Models\DashVideos;
+
+class MigrationForeignKeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dash_video_and_share_table_virtual_file_relationship(): void
+    {
+        $member = Member::factory()->create();
+        $shareTable = ShareTable::factory()->create(['member_id' => $member->id]);
+        $virtualFile = VirtualFile::factory()->create();
+
+        $stvf = ShareTableVirtualFile::create([
+            'share_table_id' => $shareTable->id,
+            'virtual_file_uuid' => $virtualFile->uuid,
+        ]);
+
+        $dashVideo = DashVideos::create([
+            'virtual_file_uuid' => $virtualFile->uuid,
+            'share_table_virtual_file_id' => $stvf->id,
+            'member_id' => $member->id,
+        ]);
+
+        $stvf->update(['dash_videos_id' => $dashVideo->id]);
+
+        $this->assertEquals($dashVideo->id, $stvf->dashVideos->id);
+        $this->assertEquals($stvf->id, $dashVideo->shareTableVirtualFile->id);
+    }
+}


### PR DESCRIPTION
## Summary
- update migrations to create dash_videos FK correctly
- link share_table_virtual_file to dash_videos with explicit FK
- fix virtual file factory column name
- fix DashVideos relation to pivot model
- add a unit test covering the pivot FKs

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685e30264bc883238d98b54548c08046